### PR TITLE
[gradle][cameraX] CameraX requires androidx.camera:camera-camera2 gradle dep

### DIFF
--- a/PyTorchDemoApp/app/build.gradle
+++ b/PyTorchDemoApp/app/build.gradle
@@ -31,7 +31,10 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "androidx.camera:camera-core:1.0.0-alpha05"
+
+    def camerax_version = "1.0.0-alpha05"
+    implementation "androidx.camera:camera-core:$camerax_version"
+    implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation 'com.google.android.material:material:1.0.0-beta01'
 
     implementation 'org.pytorch:pytorch_android:0.0.8-SNAPSHOT'


### PR DESCRIPTION
Even "androidx.camera:camera-camera2:$camerax_version" classes are not used explicitly in the app - they are required for correct work of CameraX
Without it app is crashing in runtime