### PR TITLE
fix "Lite Interpreter verson number does not match"

### DIFF
--- a/HelloWorldApp/README.md
+++ b/HelloWorldApp/README.md
@@ -7,8 +7,12 @@ This application runs TorchScript serialized TorchVision pretrained [MobileNet v
 
 Let’s start with model preparation. If you are familiar with PyTorch, you probably should already know how to train and save your model. In case you don’t, we are going to use a pre-trained image classification model(MobileNet v3), which is packaged in [TorchVision](https://pytorch.org/docs/stable/torchvision/index.html).
 To install it, run the command below:
-```
-pip install torch torchvision
+```sh
+pip install torch==1.8.2 torchvision==0.9.2
+# or
+pip install -r requirements.txt
+# maybe faster
+pip install torch==1.8.2 torchvision==0.9.2 -extra-index-url https://download.pytorch.org/whl/lts/1.8/cpu
 ```
 
 To serialize and optimize the model for Android, you can use the Python [script](https://github.com/pytorch/android-demo-app/blob/master/HelloWorldApp/trace_model.py) in the root folder of HelloWorld app:
@@ -54,14 +58,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.pytorch:pytorch_android_lite:1.9.0'
-    implementation 'org.pytorch:pytorch_android_torchvision:1.9.0'
+    implementation 'org.pytorch:pytorch_android_lite:1.12.2'
+    implementation 'org.pytorch:pytorch_android_torchvision_lite:1.12.2'
 }
 ```
-Where `org.pytorch:pytorch_android` is the main dependency with PyTorch Android API, including libtorch native library for all 4 android abis (armeabi-v7a, arm64-v8a, x86, x86_64).
+Where `org.pytorch:pytorch_android_lite` is the main dependency with PyTorch Android API, including libtorch native library for all 4 android abis (armeabi-v7a, arm64-v8a, x86, x86_64).
 Further in this doc you can find how to rebuild it only for specific list of android abis.
 
-`org.pytorch:pytorch_android_torchvision` - additional library with utility functions for converting `android.media.Image` and `android.graphics.Bitmap` to tensors.
+`org.pytorch:pytorch_android_torchvision_lite` - additional library with utility functions for converting `android.media.Image` and `android.graphics.Bitmap` to tensors.
 
 #### 4. Reading image from Android Asset
 

--- a/HelloWorldApp/app/build.gradle
+++ b/HelloWorldApp/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "29.0.2"
+    buildToolsVersion '29.0.2'
     defaultConfig {
-        applicationId "org.pytorch.helloworld"
+        applicationId 'org.pytorch.helloworld'
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
     buildTypes {
         release {
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'org.pytorch:pytorch_android_lite:1.9.0'
-    implementation 'org.pytorch:pytorch_android_torchvision:1.9.0'
+    implementation 'org.pytorch:pytorch_android_lite:1.12.2'
+    implementation 'org.pytorch:pytorch_android_torchvision_lite:1.12.2'
 }

--- a/HelloWorldApp/requirements.txt
+++ b/HelloWorldApp/requirements.txt
@@ -1,0 +1,2 @@
+torch==1.8.2
+torchvision==0.9.2


### PR DESCRIPTION
Fix the bug in Issue #202 

When I run [HelloWorldApp](https://github.com/pytorch/android-demo-app/tree/master/HelloWorldApp), I met this error: `java.lang.RuntimeException: Unable to start activity ComponentInfo{org.pytorch.helloworld/org.pytorch.helloworld.MainActivity}: com.facebook.jni.CppException: Lite Interpreter verson number does not match. The model version must be between 3 and 5But the model version is 8 ()`


My solution:
1. Specify the LTS version of torch and torchvision when running `pip install`. I also add a `requirements.txt` here.
2. Upgrade `org.pytorch:pytorch_android_lite` and `org.pytorch:pytorch_android_torchvision_lite` to latest version `1.12.2`.
3. I also update README corresponding to the above changes.

